### PR TITLE
Bump num-traits dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["double-array", "trie"]
 
 [dependencies]
 fnv = "1.0"
-num-traits = "0.1"
+num-traits = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
It seems no further changes are required (cargo test works). I didn't test if this is a breaking change for the public api.